### PR TITLE
Upgrade from `.elrond` to `.x`

### DIFF
--- a/dns/mandos/03_register_name_ok.steps.json
+++ b/dns/mandos/03_register_name_ok.steps.json
@@ -82,7 +82,7 @@
         },
         {
             "step": "scCall",
-            "txId": "resolve-coolname0001",
+            "txId": "resolve-coolname0001-x-ok",
             "tx": {
                 "from": "address:viewer",
                 "to": "sc:dns#87",
@@ -98,6 +98,28 @@
                 "out": [
                     "address:cool_address"
                 ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "resolve-coolname0001-elrond-err",
+            "tx": {
+                "from": "address:viewer",
+                "to": "sc:dns#87",
+                "value": "0",
+                "function": "resolve",
+                "arguments": [
+                    "str:coolname0001.elrond"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
                 "status": "",
                 "logs": [],
                 "gas": "*",

--- a/dns/mandos/03_register_name_ok.steps.json
+++ b/dns/mandos/03_register_name_ok.steps.json
@@ -19,13 +19,15 @@
                 "value": "0",
                 "function": "nameHash",
                 "arguments": [
-                    "str:coolname0001.elrond"
+                    "str:coolname0001.x"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {
-                "out": [ "keccak256:str:coolname0001.elrond" ],
+                "out": [
+                    "keccak256:str:coolname0001.elrond"
+                ],
                 "status": "",
                 "logs": "*",
                 "gas": "*",
@@ -41,13 +43,15 @@
                 "value": "0",
                 "function": "nameShard",
                 "arguments": [
-                    "str:coolname0001.elrond"
+                    "str:coolname0001.x"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {
-                "out": [ "0x87" ],
+                "out": [
+                    "0x87"
+                ],
                 "status": "",
                 "logs": "*",
                 "gas": "*",
@@ -63,7 +67,7 @@
                 "value": "123,000",
                 "function": "register",
                 "arguments": [
-                    "str:coolname0001.elrond"
+                    "str:coolname0001.x"
                 ],
                 "gasLimit": "40,000,000",
                 "gasPrice": "0"
@@ -85,13 +89,15 @@
                 "value": "0",
                 "function": "resolve",
                 "arguments": [
-                    "str:coolname0001.elrond"
+                    "str:coolname0001.x"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {
-                "out": [ "address:cool_address" ],
+                "out": [
+                    "address:cool_address"
+                ],
                 "status": "",
                 "logs": [],
                 "gas": "*",
@@ -104,7 +110,7 @@
                 "address:cool_address": {
                     "nonce": "*",
                     "balance": "123,000",
-                    "username": "str:coolname0001.elrond"
+                    "username": "str:coolname0001.x"
                 },
                 "sc:dns#87": {
                     "nonce": "*",
@@ -112,7 +118,7 @@
                     "storage": {
                         "''registration_cost": "123,000",
                         "''feat:register": "1",
-                        "''value_state|keccak256:str:coolname0001.elrond": "u8:2|address:cool_address"
+                        "''value_state|keccak256:str:coolname0001.elrond": "u8:5|address:cool_address"
                     },
                     "code": "file:../output/elrond-wasm-sc-dns.wasm"
                 },

--- a/dns/mandos/04_register_name_again.steps.json
+++ b/dns/mandos/04_register_name_again.steps.json
@@ -19,7 +19,7 @@
                 "value": "123,000",
                 "function": "register",
                 "arguments": [
-                    "str:coolname0001.elrond"
+                    "str:coolname0001.x"
                 ],
                 "gasLimit": "10,000,000",
                 "gasPrice": "0"
@@ -42,13 +42,15 @@
                 "value": "0",
                 "function": "resolve",
                 "arguments": [
-                    "str:coolname0001.elrond"
+                    "str:coolname0001.x"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {
-                "out": [ "address:cool_address" ],
+                "out": [
+                    "address:cool_address"
+                ],
                 "status": "",
                 "logs": "*",
                 "gas": "*",
@@ -61,7 +63,7 @@
                 "address:cool_address": {
                     "nonce": "*",
                     "balance": "123,000",
-                    "username": "str:coolname0001.elrond"
+                    "username": "str:coolname0001.x"
                 },
                 "sc:dns#87": {
                     "nonce": "*",
@@ -69,7 +71,7 @@
                     "storage": {
                         "''registration_cost": "123,000",
                         "''feat:register": "1",
-                        "''value_state|keccak256:str:coolname0001.elrond": "u8:2|address:cool_address"
+                        "''value_state|keccak256:str:coolname0001.elrond": "u8:5|address:cool_address"
                     },
                     "code": "file:../output/elrond-wasm-sc-dns.wasm"
                 },

--- a/dns/mandos/06_register_other_name_same_shard.steps.json
+++ b/dns/mandos/06_register_other_name_same_shard.steps.json
@@ -1,7 +1,6 @@
 {
     "name": "register, name taken",
     "steps": [
-        
         {
             "step": "scCall",
             "txId": "try-register-coolname1075-same-user",
@@ -12,7 +11,7 @@
                 "value": "123,000",
                 "function": "register",
                 "arguments": [
-                    "str:coolname1075.elrond"
+                    "str:coolname1075.x"
                 ],
                 "gasLimit": "10,000,000",
                 "gasPrice": "0"
@@ -34,7 +33,7 @@
                 "value": "0",
                 "function": "resolve",
                 "arguments": [
-                    "str:coolname1075.elrond"
+                    "str:coolname1075.x"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -53,7 +52,7 @@
                 "address:cool_address": {
                     "nonce": "*",
                     "balance": "0",
-                    "username": "str:coolname0001.elrond"
+                    "username": "str:coolname0001.x"
                 },
                 "sc:dns#87": {
                     "nonce": "*",
@@ -61,7 +60,7 @@
                     "storage": {
                         "''registration_cost": "123,000",
                         "''feat:register": "1",
-                        "''value_state|keccak256:str:coolname0001.elrond": "u8:2|address:cool_address"
+                        "''value_state|keccak256:str:coolname0001.elrond": "u8:5|address:cool_address"
                     },
                     "code": "file:../output/elrond-wasm-sc-dns.wasm"
                 },

--- a/dns/mandos/migrate.scen.json
+++ b/dns/mandos/migrate.scen.json
@@ -1,0 +1,76 @@
+{
+    "name": "dns migrate test",
+    "gasSchedule": "dummy",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "01_dns_init.steps.json"
+        },
+        {
+            "step": "externalSteps",
+            "path": "02_dns_init_check.steps.json"
+        },
+        {
+            "step": "setState",
+            "accounts": {
+                "address:cool_address": {
+                    "nonce": "0",
+                    "balance": "123,000",
+                    "username": "str:coolname0001.elrond"
+                },
+                "sc:dns#87": {
+                    "nonce": "0",
+                    "balance": "123,000",
+                    "storage": {
+                        "''registration_cost": "123,000",
+                        "''feat:register": "1",
+                        "''value_state|keccak256:str:coolname0001.elrond": "u8:2|address:cool_address"
+                    },
+                    "code": "file:../output/elrond-wasm-sc-dns.wasm"
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "migrate-ok",
+            "tx": {
+                "from": "address:cool_address",
+                "to": "sc:dns#87",
+                "value": "0",
+                "function": "migrate",
+                "arguments": [
+                    "str:coolname0001.elrond"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:cool_address": {
+                    "nonce": "*",
+                    "balance": "123,000",
+                    "username": "str:coolname0001.x"
+                },
+                "sc:dns#87": {
+                    "nonce": "*",
+                    "balance": "123,000",
+                    "storage": {
+                        "''registration_cost": "123,000",
+                        "''feat:register": "1",
+                        "''value_state|keccak256:str:coolname0001.elrond": "u8:5|address:cool_address"
+                    },
+                    "code": "file:../output/elrond-wasm-sc-dns.wasm"
+                }
+            }
+        }
+    ]
+}

--- a/dns/mandos/resolve-elrond.scen.json
+++ b/dns/mandos/resolve-elrond.scen.json
@@ -1,0 +1,80 @@
+{
+    "name": "dns resolve elrond test",
+    "gasSchedule": "dummy",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "01_dns_init.steps.json"
+        },
+        {
+            "step": "externalSteps",
+            "path": "02_dns_init_check.steps.json"
+        },
+        {
+            "step": "setState",
+            "accounts": {
+                "address:cool_address": {
+                    "nonce": "0",
+                    "balance": "123,000",
+                    "username": "str:coolname0001.elrond"
+                },
+                "sc:dns#87": {
+                    "nonce": "0",
+                    "balance": "123,000",
+                    "storage": {
+                        "''registration_cost": "123,000",
+                        "''feat:register": "1",
+                        "''value_state|keccak256:str:coolname0001.elrond": "u8:2|address:cool_address"
+                    },
+                    "code": "file:../output/elrond-wasm-sc-dns.wasm"
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "resolve-coolname0001-elrond-err",
+            "tx": {
+                "from": "address:viewer",
+                "to": "sc:dns#87",
+                "value": "0",
+                "function": "resolve",
+                "arguments": [
+                    "str:coolname0001.elrond"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "address:cool_address"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "resolve-coolname0001-x-err",
+            "tx": {
+                "from": "address:viewer",
+                "to": "sc:dns#87",
+                "value": "0",
+                "function": "resolve",
+                "arguments": [
+                    "str:coolname0001.x"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        }
+    ]
+}

--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -4,6 +4,7 @@ pub mod name_validation;
 pub mod user_builtin;
 pub mod value_state;
 
+use name_validation::SuffixType;
 use value_state::ValueState;
 
 elrond_wasm::imports!();
@@ -39,7 +40,7 @@ pub trait Dns: elrond_wasm_modules::features::FeaturesModule {
 
     /// `name_hash` is redundant, but passed to the method so we don't compute it twice.
     fn validate_register_input(&self, name: &ManagedBuffer, name_hash: &NameHash<Self::Api>) {
-        self.check_feature_on(b"register", true);
+        self.check_register_feature_on();
 
         self.validate_name(name);
 
@@ -47,6 +48,10 @@ pub trait Dns: elrond_wasm_modules::features::FeaturesModule {
 
         let vs = self.value_state(name_hash).get();
         require!(vs.is_available(), "name already taken");
+    }
+
+    fn check_register_feature_on(&self) {
+        self.check_feature_on(b"register", true);
     }
 
     #[view(canRegister)]
@@ -69,85 +74,101 @@ pub trait Dns: elrond_wasm_modules::features::FeaturesModule {
 
         let address = self.blockchain().get_caller();
         self.value_state(&name_hash)
-            .set(&ValueState::Pending(address.clone()));
+            .set(&ValueState::PendingX(address.clone()));
 
+        let gas_limit = self.update_gas_limit().get();
         self.user_builtin_proxy(address)
             .set_user_name(&name)
+            .with_gas_limit(gas_limit)
             .async_call()
-            .with_callback(self.callbacks().set_user_name_callback(&name_hash))
+            .with_callback(self.callbacks().update_value_state_callback(&name_hash))
             .call_and_exit()
     }
 
+    #[endpoint]
+    fn migrate(&self, name: ManagedBuffer) {
+        let name_with_x_suffix = name_validation::prepare_and_validate_name_for_migration(&name)
+            .unwrap_or_else(|err| sc_panic!(err));
+
+        self.check_register_feature_on();
+
+        let name_hash = self.unchecked_name_hash(&name);
+
+        self.validate_name_shard(&name_hash);
+
+        let address = self.value_state(&name_hash).update(|vs| {
+            let address = vs.start_migration();
+
+            let caller = self.blockchain().get_caller();
+            require!(caller == address, "name not owned by the caller");
+            address
+        });
+
+        let gas_limit = self.update_gas_limit().get();
+        self.user_builtin_proxy(address)
+            .migrate_user_name(&name_with_x_suffix)
+            .with_gas_limit(gas_limit)
+            .async_call()
+            .with_callback(self.callbacks().update_value_state_callback(&name_hash))
+            .call_and_exit();
+    }
+
     #[callback]
-    fn set_user_name_callback(
+    fn update_value_state_callback(
         &self,
         cb_name_hash: &NameHash<Self::Api>,
         #[call_result] result: ManagedAsyncCallResult<()>,
     ) {
-        match result {
-            ManagedAsyncCallResult::Ok(()) => {
-                // commit
-                self.value_state(cb_name_hash).update(|vs| {
-                    *vs = if let ValueState::Pending(addr) = vs {
-                        ValueState::Committed(addr.clone())
-                    } else {
-                        ValueState::None
-                    }
-                });
+        self.value_state(cb_name_hash).update(|vs| {
+            if result.is_ok() {
+                vs.finalize();
+            } else {
+                vs.revert();
             }
-            ManagedAsyncCallResult::Err(_) => {
-                // revert
-                self.value_state(cb_name_hash).set(&ValueState::None);
-            }
-        }
+        });
     }
 
     #[view]
     fn resolve(&self, name: &ManagedBuffer) -> OptionalValue<ManagedAddress> {
-        let name_hash = self.name_hash(name);
+        let (name_hash, computed_suffix_type) = self.compute_name_hash_and_classify(name);
         self.resolve_from_hash(name_hash)
+            .into_option()
+            .and_then(|address_suffix_multi_value| {
+                let (address, stored_suffix_type) = address_suffix_multi_value.into_tuple();
+                if computed_suffix_type == stored_suffix_type {
+                    Some(address)
+                } else {
+                    None
+                }
+            })
+            .into()
     }
 
     #[view(resolveFromHash)]
-    fn resolve_from_hash(&self, name_hash: NameHash<Self::Api>) -> OptionalValue<ManagedAddress> {
+    fn resolve_from_hash(
+        &self,
+        name_hash: NameHash<Self::Api>,
+    ) -> OptionalValue<MultiValue2<ManagedAddress, SuffixType>> {
         if sibling_id(&name_hash.to_byte_array()) != self.get_own_sibling_id() {
             return OptionalValue::None;
         }
 
         let vs = self.value_state(&name_hash).get();
-        if let ValueState::Committed(address) = vs {
-            OptionalValue::Some(address)
-        } else {
-            OptionalValue::None
+        match vs {
+            ValueState::RegisteredX(address) => {
+                OptionalValue::Some((address, SuffixType::X).into())
+            }
+            ValueState::RegisteredElrond(address) => {
+                OptionalValue::Some((address, SuffixType::Elrond).into())
+            }
+            _ => OptionalValue::None,
         }
     }
 
-    #[view(checkPending)]
-    fn check_pending(&self, name: &ManagedBuffer) -> OptionalValue<ManagedAddress> {
+    #[view(getNameState)]
+    fn get_name_state(&self, name: &ManagedBuffer) -> ValueState<Self::Api> {
         let name_hash = self.name_hash(name);
-        if sibling_id(&name_hash.to_byte_array()) != self.get_own_sibling_id() {
-            return OptionalValue::None;
-        }
-
-        let vs = self.value_state(&name_hash).get();
-        if let ValueState::Pending(address) = vs {
-            OptionalValue::Some(address)
-        } else {
-            OptionalValue::None
-        }
-    }
-
-    #[only_owner]
-    #[view(resetPending)]
-    fn reset_pending(&self, name: &ManagedBuffer) {
-        let name_hash = self.name_hash(name);
-        self.validate_name_shard(&name_hash);
-
-        let vs_mapper = self.value_state(&name_hash);
-        let vs = vs_mapper.get();
-        if let ValueState::Pending(_) = vs {
-            vs_mapper.set(&ValueState::None);
-        }
+        self.value_state(&name_hash).get()
     }
 
     #[only_owner]
@@ -161,17 +182,28 @@ pub trait Dns: elrond_wasm_modules::features::FeaturesModule {
         );
     }
 
+    #[only_owner]
+    #[endpoint(setUpdateGasLimit)]
+    fn set_update_gas_limit(&self, gas_limit: u64) {
+        self.update_gas_limit().set(gas_limit);
+    }
+
     // STORAGE
 
     #[view(getRegistrationCost)]
     #[storage_mapper("registration_cost")]
     fn registration_cost(&self) -> SingleValueMapper<BigUint>;
 
+    #[view(getValueState)]
     #[storage_mapper("value_state")]
     fn value_state(
         &self,
         name_hash: &NameHash<Self::Api>,
     ) -> SingleValueMapper<ValueState<Self::Api>>;
+
+    #[view(getUpdateGasLimit)]
+    #[storage_mapper("update_gas_limit")]
+    fn update_gas_limit(&self) -> SingleValueMapper<u64>;
 
     // UTILS
 
@@ -188,6 +220,21 @@ pub trait Dns: elrond_wasm_modules::features::FeaturesModule {
 
     #[view(nameHash)]
     fn name_hash(&self, name: &ManagedBuffer) -> NameHash<Self::Api> {
+        let (name_hash, _) = self.compute_name_hash_and_classify(name);
+        name_hash
+    }
+
+    fn compute_name_hash_and_classify(
+        &self,
+        name: &ManagedBuffer,
+    ) -> (NameHash<Self::Api>, SuffixType) {
+        let (prepared_name, suffix_type) =
+            name_validation::prepare_name_for_hash_and_classify(name);
+        let name_hash = self.unchecked_name_hash(&prepared_name);
+        (name_hash, suffix_type)
+    }
+
+    fn unchecked_name_hash(&self, name: &ManagedBuffer) -> NameHash<Self::Api> {
         self.crypto().keccak256(name)
     }
 

--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -165,8 +165,8 @@ pub trait Dns: elrond_wasm_modules::features::FeaturesModule {
         }
     }
 
-    #[view(getNameState)]
-    fn get_name_state(&self, name: &ManagedBuffer) -> ValueState<Self::Api> {
+    #[view(getNameValueState)]
+    fn get_name_value_state(&self, name: &ManagedBuffer) -> ValueState<Self::Api> {
         let name_hash = self.name_hash(name);
         self.value_state(&name_hash).get()
     }

--- a/dns/src/name_validation.rs
+++ b/dns/src/name_validation.rs
@@ -1,44 +1,30 @@
 elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
 
 const MIN_LENGTH: usize = 3;
 pub const MAX_LENGTH: usize = 32;
-const NAME_SUFFIX: &[u8] = b".elrond";
+const ELROND_SUFFIX: &[u8] = b".elrond";
+const X_SUFFIX: &[u8] = b".x";
 
-#[allow(clippy::manual_range_contains)]
+#[derive(TopEncode, TopDecode, TypeAbi, PartialEq, Debug)]
+pub enum SuffixType {
+    Elrond,
+    X,
+}
+
 fn check_name_char(ch: u8) -> bool {
-    if ch >= b'a' && ch <= b'z' {
-        return true;
-    }
-
-    if ch >= b'0' && ch <= b'9' {
-        return true;
-    }
-
-    false
+    ch.is_ascii_lowercase() || ch.is_ascii_digit()
 }
 
 pub fn validate_name<M: ManagedTypeApi>(name: &ManagedBuffer<M>) -> Result<(), &'static str> {
-    let name_len = name.len();
-    if name_len <= NAME_SUFFIX.len() {
-        return Result::Err("name does not contain suffix");
-    }
+    let name_cache = NameCache::try_load(name)?;
 
-    if name_len > MAX_LENGTH {
-        return Result::Err("name too long");
-    }
+    let name_without_suffix = name_cache.check_suffix(X_SUFFIX)?;
+    validate_name_without_suffix(name_without_suffix)?;
+    Result::Ok(())
+}
 
-    let mut name_bytes = [0u8; MAX_LENGTH];
-    let name_slice = &mut name_bytes[..name_len];
-    if name.load_slice(0, name_slice).is_err() {
-        return Result::Err("error loading name bytes");
-    }
-
-    let (name_without_suffix, suffix) = name_slice.split_at(name.len() - NAME_SUFFIX.len());
-
-    if suffix != NAME_SUFFIX {
-        return Result::Err("wrong suffix");
-    }
-
+fn validate_name_without_suffix(name_without_suffix: &[u8]) -> Result<(), &'static str> {
     if name_without_suffix.len() < MIN_LENGTH {
         return Result::Err("name is too short");
     }
@@ -48,6 +34,93 @@ pub fn validate_name<M: ManagedTypeApi>(name: &ManagedBuffer<M>) -> Result<(), &
             return Result::Err("character not allowed");
         }
     }
-
     Result::Ok(())
+}
+
+// switch the suffix from .x to .elrond for the purpose of name hashing
+// all other names (eg. using the .elrond suffix, or some invalid names), are not modified
+pub fn prepare_name_for_hash_and_classify<M: ManagedTypeApi>(
+    name: &ManagedBuffer<M>,
+) -> (ManagedBuffer<M>, SuffixType) {
+    try_replace_suffix(name, X_SUFFIX, ELROND_SUFFIX).map_or_else(
+        |_| (name.clone(), SuffixType::Elrond),
+        |new_name| (new_name, SuffixType::X),
+    )
+}
+
+fn try_replace_suffix<M: ManagedTypeApi>(
+    name: &ManagedBuffer<M>,
+    original_suffix: &'static [u8],
+    new_suffix: &'static [u8],
+) -> Result<ManagedBuffer<M>, &'static str> {
+    let name_cache = NameCache::try_load(name)?;
+    let name_without_suffix = name_cache.check_suffix(original_suffix)?;
+    let new_name = build_name(name_without_suffix, new_suffix);
+    Result::Ok(new_name)
+}
+
+// ensure the suffix is .elrond and replace it with .x
+// validate the name without the prefix as well
+pub fn prepare_and_validate_name_for_migration<M: ManagedTypeApi>(
+    name: &ManagedBuffer<M>,
+) -> Result<ManagedBuffer<M>, &'static str> {
+    let name_cache = NameCache::try_load(name)?;
+    let name_without_suffix = name_cache.check_suffix(ELROND_SUFFIX)?;
+    validate_name_without_suffix(name_without_suffix)?;
+    let new_name = build_name(name_without_suffix, X_SUFFIX);
+    Result::Ok(new_name)
+}
+
+fn build_name<M: ManagedTypeApi>(name_without_suffix: &[u8], suffix: &[u8]) -> ManagedBuffer<M> {
+    let mut name = ManagedBuffer::from(name_without_suffix);
+    name.append_bytes(suffix);
+    name
+}
+
+struct NameCache {
+    name_bytes: [u8; MAX_LENGTH],
+    name_len: usize,
+}
+
+impl NameCache {
+    pub fn try_load<M: ManagedTypeApi>(name: &ManagedBuffer<M>) -> Result<Self, &'static str> {
+        let name_len = name.len();
+        if name_len > MAX_LENGTH {
+            return Result::Err("name too long");
+        }
+
+        let mut name_cache = Self {
+            name_bytes: [0u8; MAX_LENGTH],
+            name_len,
+        };
+
+        let name_slice = name_cache.as_mut_slice();
+        if name.load_slice(0, name_slice).is_err() {
+            return Result::Err("error loading name bytes");
+        }
+        Result::Ok(name_cache)
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.name_bytes[..self.name_len]
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.name_bytes[..self.name_len]
+    }
+
+    pub fn check_suffix(&self, suffix: &[u8]) -> Result<&[u8], &'static str> {
+        if self.name_len < suffix.len() {
+            return Result::Err("name does not contain suffix");
+        }
+
+        let (name_without_suffix, name_suffix) =
+            self.as_slice().split_at(self.name_len - suffix.len());
+
+        if name_suffix != suffix {
+            return Result::Err("wrong suffix");
+        }
+
+        Result::Ok(name_without_suffix)
+    }
 }

--- a/dns/src/name_validation.rs
+++ b/dns/src/name_validation.rs
@@ -20,8 +20,7 @@ pub fn validate_name<M: ManagedTypeApi>(name: &ManagedBuffer<M>) -> Result<(), &
     let name_cache = NameCache::try_load(name)?;
 
     let name_without_suffix = name_cache.check_suffix(X_SUFFIX)?;
-    validate_name_without_suffix(name_without_suffix)?;
-    Result::Ok(())
+    validate_name_without_suffix(name_without_suffix)
 }
 
 fn validate_name_without_suffix(name_without_suffix: &[u8]) -> Result<(), &'static str> {

--- a/dns/src/name_validation.rs
+++ b/dns/src/name_validation.rs
@@ -19,7 +19,7 @@ fn check_name_char(ch: u8) -> bool {
 pub fn validate_name<M: ManagedTypeApi>(name: &ManagedBuffer<M>) -> Result<(), &'static str> {
     let name_cache = NameCache::try_load(name)?;
 
-    let name_without_suffix = name_cache.check_suffix(X_SUFFIX)?;
+    let name_without_suffix = name_cache.check_suffix_and_get_name(X_SUFFIX)?;
     validate_name_without_suffix(name_without_suffix)
 }
 
@@ -53,7 +53,7 @@ fn try_replace_suffix<M: ManagedTypeApi>(
     new_suffix: &'static [u8],
 ) -> Result<ManagedBuffer<M>, &'static str> {
     let name_cache = NameCache::try_load(name)?;
-    let name_without_suffix = name_cache.check_suffix(original_suffix)?;
+    let name_without_suffix = name_cache.check_suffix_and_get_name(original_suffix)?;
     let new_name = build_name(name_without_suffix, new_suffix);
     Result::Ok(new_name)
 }
@@ -64,7 +64,7 @@ pub fn prepare_and_validate_name_for_migration<M: ManagedTypeApi>(
     name: &ManagedBuffer<M>,
 ) -> Result<ManagedBuffer<M>, &'static str> {
     let name_cache = NameCache::try_load(name)?;
-    let name_without_suffix = name_cache.check_suffix(ELROND_SUFFIX)?;
+    let name_without_suffix = name_cache.check_suffix_and_get_name(ELROND_SUFFIX)?;
     validate_name_without_suffix(name_without_suffix)?;
     let new_name = build_name(name_without_suffix, X_SUFFIX);
     Result::Ok(new_name)
@@ -108,7 +108,7 @@ impl NameCache {
         &mut self.name_bytes[..self.name_len]
     }
 
-    pub fn check_suffix(&self, suffix: &[u8]) -> Result<&[u8], &'static str> {
+    pub fn check_suffix_and_get_name(&self, suffix: &[u8]) -> Result<&[u8], &'static str> {
         if self.name_len < suffix.len() {
             return Result::Err("name does not contain suffix");
         }

--- a/dns/src/user_builtin.rs
+++ b/dns/src/user_builtin.rs
@@ -3,5 +3,8 @@ elrond_wasm::imports!();
 #[elrond_wasm::derive::proxy]
 pub trait UserBuiltin {
     #[endpoint(SetUserName)]
-    fn set_user_name(&self, name: &ManagedBuffer) -> BigUint;
+    fn set_user_name(&self, name: &ManagedBuffer);
+
+    #[endpoint(migrateUserName)]
+    fn migrate_user_name(&self, name: &ManagedBuffer);
 }

--- a/dns/src/value_state.rs
+++ b/dns/src/value_state.rs
@@ -5,7 +5,6 @@ use elrond_wasm::{
 
 elrond_wasm::derive_imports!();
 
-/// Copied from elrond-wasm serialization tests.
 #[derive(
     NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi, PartialEq, Eq, Debug, Clone,
 )]

--- a/dns/src/value_state.rs
+++ b/dns/src/value_state.rs
@@ -1,17 +1,54 @@
-use elrond_wasm::{api::ManagedTypeApi, types::ManagedAddress};
+use elrond_wasm::{
+    api::{ErrorApiImpl, ManagedTypeApi},
+    types::ManagedAddress,
+};
 
 elrond_wasm::derive_imports!();
 
 /// Copied from elrond-wasm serialization tests.
-#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi, PartialEq, Eq, Debug)]
+#[derive(
+    NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi, PartialEq, Eq, Debug, Clone,
+)]
 pub enum ValueState<M: ManagedTypeApi> {
     None,
-    Pending(ManagedAddress<M>),
-    Committed(ManagedAddress<M>),
+    PendingElrond(ManagedAddress<M>),
+    RegisteredElrond(ManagedAddress<M>),
+    PendingMigration(ManagedAddress<M>),
+    PendingX(ManagedAddress<M>),
+    RegisteredX(ManagedAddress<M>),
 }
 
 impl<M: ManagedTypeApi> ValueState<M> {
     pub fn is_available(&self) -> bool {
         matches!(self, ValueState::None)
+    }
+
+    pub fn start_migration(&mut self) -> ManagedAddress<M> {
+        let result;
+        *self = if let ValueState::RegisteredElrond(address) = self {
+            result = address.clone();
+            ValueState::PendingMigration(address.clone())
+        } else {
+            M::error_api_impl().signal_error(b"can't migrate")
+        };
+        result
+    }
+
+    pub fn finalize(&mut self) {
+        *self = match self {
+            Self::PendingElrond(address) => Self::RegisteredElrond(address.clone()),
+            Self::PendingMigration(address) => Self::RegisteredX(address.clone()),
+            Self::PendingX(address) => Self::RegisteredX(address.clone()),
+            _ => Self::None,
+        };
+    }
+
+    pub fn revert(&mut self) {
+        *self = match self {
+            Self::PendingElrond(_) => Self::None,
+            Self::PendingMigration(address) => Self::RegisteredElrond(address.clone()),
+            Self::PendingX(_) => Self::None,
+            _ => Self::None,
+        }
     }
 }

--- a/dns/tests/mandos_go_tests.rs
+++ b/dns/tests/mandos_go_tests.rs
@@ -1,0 +1,16 @@
+#[test]
+#[ignore = "there are differences in the emitted logs (transferValueOnly)"]
+fn test_mandos_main_go() {
+    elrond_wasm_debug::mandos_go("mandos/main.scen.json");
+}
+
+#[test]
+fn test_mandos_resolve_elrond_go() {
+    elrond_wasm_debug::mandos_go("mandos/resolve-elrond.scen.json");
+}
+
+#[test]
+#[ignore = "migrateUserName builtin function not implemented yet"]
+fn test_mandos_migrate_go() {
+    elrond_wasm_debug::mandos_go("mandos/migrate.scen.json");
+}

--- a/dns/tests/mandos_rs_tests.rs
+++ b/dns/tests/mandos_rs_tests.rs
@@ -21,7 +21,6 @@ fn test_mandos_resolve_elrond_rs() {
     elrond_wasm_debug::mandos_rs("mandos/resolve-elrond.scen.json", world());
 }
 
-// TODO: enable test when the migrateUserName builtin function is implemented the rust framework
 #[test]
 #[ignore = "migrateUserName builtin function not implemented yet"]
 fn test_mandos_migrate_rs() {

--- a/dns/tests/mandos_test.rs
+++ b/dns/tests/mandos_test.rs
@@ -15,3 +15,15 @@ fn world() -> BlockchainMock {
 fn test_mandos_main_rs() {
     elrond_wasm_debug::mandos_rs("mandos/main.scen.json", world());
 }
+
+#[test]
+fn test_mandos_resolve_elrond_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/resolve-elrond.scen.json", world());
+}
+
+// TODO: enable test when the migrateUserName builtin function is implemented the rust framework
+#[test]
+#[ignore = "migrateUserName builtin function not implemented yet"]
+fn test_mandos_migrate_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/migrate.scen.json", world());
+}

--- a/dns/tests/prepare_name_for_hash_test.rs
+++ b/dns/tests/prepare_name_for_hash_test.rs
@@ -1,0 +1,48 @@
+use elrond_wasm::types::ManagedBuffer;
+use elrond_wasm_debug::DebugApi;
+use elrond_wasm_sc_dns::name_validation::SuffixType;
+
+fn prepare_name_for_hash_and_classify(name_str: &str) -> (ManagedBuffer<DebugApi>, SuffixType) {
+    let mb = ManagedBuffer::<DebugApi>::from(name_str.as_bytes());
+    elrond_wasm_sc_dns::name_validation::prepare_name_for_hash_and_classify(&mb)
+}
+
+fn check(name: &str, expected: &str, suffix_type: SuffixType) {
+    assert_eq!(
+        prepare_name_for_hash_and_classify(name),
+        (ManagedBuffer::from(expected.as_bytes()), suffix_type)
+    );
+}
+
+#[test]
+fn prepare_name_for_hash_test() {
+    let _ = DebugApi::dummy();
+
+    // .x is replaced with .elrond
+    check("aaa.x", "aaa.elrond", SuffixType::X);
+    check("aaaaaaaaaa.x", "aaaaaaaaaa.elrond", SuffixType::X);
+    check("zzzzzzzzzz.x", "zzzzzzzzzz.elrond", SuffixType::X);
+    check("0000000000.x", "0000000000.elrond", SuffixType::X);
+    check("9999999999.x", "9999999999.elrond", SuffixType::X);
+    check("coolname0001.x", "coolname0001.elrond", SuffixType::X);
+
+    // .elrond names are returned unchanged
+    check("aaa.elrond", "aaa.elrond", SuffixType::Elrond);
+    check("aaaaaaaaaa.elrond", "aaaaaaaaaa.elrond", SuffixType::Elrond);
+    check("zzzzzzzzzz.elrond", "zzzzzzzzzz.elrond", SuffixType::Elrond);
+    check("0000000000.elrond", "0000000000.elrond", SuffixType::Elrond);
+    check("9999999999.elrond", "9999999999.elrond", SuffixType::Elrond);
+    check(
+        "coolname0001.elrond",
+        "coolname0001.elrond",
+        SuffixType::Elrond,
+    );
+
+    // undefined behavior for invalid names
+    // tests are only for ensuring that the function doesn't panic
+    check("aa.x", "aa.elrond", SuffixType::X);
+    check("test.abc.x", "test.abc.elrond", SuffixType::X);
+    check("test.abc.foo", "test.abc.foo", SuffixType::Elrond);
+    check("test", "test", SuffixType::Elrond);
+    check("test.abc", "test.abc", SuffixType::Elrond);
+}

--- a/dns/wasm/src/lib.rs
+++ b/dns/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           15
+// Endpoints:                           18
 // Async Callback:                       1
-// Total number of exported functions:  17
+// Total number of exported functions:  20
 
 #![no_std]
 
@@ -16,12 +16,15 @@ elrond_wasm_node::wasm_endpoints! {
     (
         canRegister
         register
+        migrate
         resolve
         resolveFromHash
-        checkPending
-        resetPending
+        getNameValueState
         claim
+        setUpdateGasLimit
         getRegistrationCost
+        getValueState
+        getUpdateGasLimit
         getContractOwner
         getOwnShardId
         nameHash


### PR DESCRIPTION
Updated the dns contract to use the `.x` domain
  - new `register` calls only accept `.x` domains (`.elrond` is no longer accepted - resulting in a `wrong suffix` error)
  - existing `.elrond` names can be migrated to `.x` through the `migrate` endpoint
  - `resolve` works for both existing `.elrond` names, as well as new `.x` names (either migrated or newly registered)

Compatibility notes:
- renamed `ValueState` enum variants: `Pending` to `PendingElrond` and `Committed` to `RegisteredElrond`, which remain backwards compatible (as they have the same determinant) and added new states (`PendingMigration`, `PendingX`, `RegisteredX`) for managing `.x` names

Introduced `setUpdateGasLimit` endpoint, which sets the gas limit to be used for the builtin function calls + callback (for both register and migrate). This change should prevent the callback from failing due to a lack of gas. Removed the `checkPending` and `resetPending` endpoints since these were used for recovering from a failed callback. Instead, provided `getNameValueState` and `getValueState` for inspecting the value state.